### PR TITLE
beautify lottery unusednumbers

### DIFF
--- a/Modules/Lottery/LotteryInteraction.cs
+++ b/Modules/Lottery/LotteryInteraction.cs
@@ -202,7 +202,7 @@ public class LotteryInteraction : InteractionModuleBase<SocketInteractionContext
 			rows.Add(string.Join(", ", formattedNumbers.Skip(i).Take(10)));
 		}
 		string numbers = string.Join("\n", rows);
-		await RespondAsync($"Currently unused: {numbers}", ephemeral: true);
+		await RespondAsync($"Currently unused: \n{numbers}", ephemeral: true);
 	}
 
 


### PR DESCRIPTION
output will now be in a grid with the taken numbers replaced by "__"
e.g. with the numbers 1,11,15 taken it should look like this:

"Currently unused: 
xx, __, 02, 03, 04, 05, 06, 07, 08, 09
10, __, 12, 13, 14, __, 16, 17, 18, 19
20, 21, 22, 23, 24, 25, 26, 27, 28, 29
30, 31, 32, 33, 34, 35, 36, 37, 38, 39
40, 41, 42, 43, 44, 45, 46, 47, 48, 49
50, 51, 52, 53, 54, 55, 56, 57, 58, 59
60, 61, 62, 63, 64, 65, 66, 67, 68, 69
70, 71, 72, 73, 74, 75, 76, 77, 78, 79
80, 81, 82, 83, 84, 85, 86, 87, 88, 89
90, 91, 92, 93, 94, 95, 96, 97, 98, 99
"