### PR TITLE
Repeat Luckydip for all guesses, Luckydip default to unused numbers, punctuation, Limit user input range

### DIFF
--- a/Modules/Lottery/LotteryInteraction.cs
+++ b/Modules/Lottery/LotteryInteraction.cs
@@ -186,8 +186,23 @@ public class LotteryInteraction : InteractionModuleBase<SocketInteractionContext
 	[SlashCommand("unusednumbers", "Check what numbers have not yet been used.")]
 	public async Task UnusedNumbers()
 	{
-		var numbers = (await GetNotGuessedNumbers()).Select(num => num.ToString()).ToList().PrettyJoin();
-		await RespondAsync($"Currently unused: {numbers}", ephemeral: true);
+        // var numbers = (await GetNotGuessedNumbers()).Select(num => num.ToString()).ToList().PrettyJoin();
+        var GuessedNumbers = (await GetGuessedNumbers());
+
+		var lotteryRange = Enumerable.Range(1,99).ToList(); // maybe make range a config parameter
+		var formattedNumbers = lotteryRange.Select(num => GuessedNumbers.Contains(num) ? "__" : num.ToString("D2")).ToList();
+
+        //insert placeholder for the missing 0 in the first line
+        formattedNumbers.Insert(0, "xx");
+
+       //split into rows of 10
+        var rows = new List<string>();
+        for (int i = 0; i < formattedNumbers.Count; i+=10)
+        {
+            rows.Add(string.Join(", ", formattedNumbers.Skip(i).Take(10)));
+        }
+		string numbers = string.Join("\n", rows);
+        await RespondAsync($"Currently unused: {numbers}", ephemeral: true);
 	}
 
 

--- a/Modules/Lottery/LotteryInteraction.cs
+++ b/Modules/Lottery/LotteryInteraction.cs
@@ -202,7 +202,7 @@ public class LotteryInteraction : InteractionModuleBase<SocketInteractionContext
 			rows.Add(string.Join(", ", formattedNumbers.Skip(i).Take(10)));
 		}
 		string numbers = string.Join("\n", rows);
-		await RespondAsync($"Currently unused: {numbers}", ephemeral: true);
+		await RespondAsync($"Currently unused: \n{numbers}", ephemeral: true);
 	}
 
 

--- a/Modules/Lottery/LotteryInteraction.cs
+++ b/Modules/Lottery/LotteryInteraction.cs
@@ -217,7 +217,7 @@ public class LotteryInteraction : InteractionModuleBase<SocketInteractionContext
 
 
 	[SlashCommand("luckydip", "Spin the wheel and maybe you'll win!")]
-	public async Task RandomGuess([Summary("number-pool", "Determines whether to use a random number from 1-99, unguessed or guessed numbers (default: 1-99)")] RandomGuessType numberPool = RandomGuessType.Any)
+	public async Task RandomGuess([Summary("number-pool", "Determines whether to use a random number from 1-99, unguessed or guessed numbers (default: ungessed numbers)")] RandomGuessType numberPool = RandomGuessType.UnusedOnly)
 	{
 		var cts = new CancellationTokenSource();
 		var task = TryRandomGuess(cts.Token, numberPool);

--- a/Modules/Lottery/LotteryInteraction.cs
+++ b/Modules/Lottery/LotteryInteraction.cs
@@ -186,8 +186,23 @@ public class LotteryInteraction : InteractionModuleBase<SocketInteractionContext
 	[SlashCommand("unusednumbers", "Check what numbers have not yet been used.")]
 	public async Task UnusedNumbers()
 	{
-		var numbers = (await GetNotGuessedNumbers()).Select(num => num.ToString()).ToList().PrettyJoin();
-		await RespondAsync($"Currently unused: {numbers}", ephemeral: true);
+		// var numbers = (await GetNotGuessedNumbers()).Select(num => num.ToString()).ToList().PrettyJoin();
+		var GuessedNumbers = (await GetGuessedNumbers());
+
+		var lotteryRange = Enumerable.Range(1,99).ToList(); // maybe make range a config parameter
+		var formattedNumbers = lotteryRange.Select(num => GuessedNumbers.Contains(num) ? "__" : num.ToString("D2")).ToList();
+
+		//insert placeholder for the missing 0 in the first line
+		formattedNumbers.Insert(0, "xx");
+
+		//split into rows of 10
+		var rows = new List<string>();
+		for (int i = 0; i < formattedNumbers.Count; i+=10)
+		{
+			rows.Add(string.Join(", ", formattedNumbers.Skip(i).Take(10)));
+		}
+		string numbers = string.Join("\n", rows);
+		await RespondAsync($"Currently unused: \n{numbers}", ephemeral: true);
 	}
 
 

--- a/Modules/Lottery/LotteryInteraction.cs
+++ b/Modules/Lottery/LotteryInteraction.cs
@@ -186,7 +186,7 @@ public class LotteryInteraction : InteractionModuleBase<SocketInteractionContext
 	[SlashCommand("unused", "Check what numbers have not yet been used.")]
 	public async Task UnusedNumbers()
 	{
-		var guessedNumbers = (await GetGuessedNumbers());
+		var guessedNumbers = await GetGuessedNumbers();
 		var formattedNumbers = (List<string>)["  ", .. Enumerable.Range(1, 99).Select(num => guessedNumbers.Contains(num) ? "__" : num.ToString("D2"))];
 		var output = string.Join('\n', formattedNumbers.Chunk(10).Select(subList => string.Join(' ', subList)));
 		await RespondAsync($"```{output}```", ephemeral: true);

--- a/Modules/Lottery/LotteryInteraction.cs
+++ b/Modules/Lottery/LotteryInteraction.cs
@@ -178,7 +178,7 @@ public class LotteryInteraction : InteractionModuleBase<SocketInteractionContext
 			NoMoreGuessesGuessResponse r =>
 				$"You don't have any guesses left! Current guesses: {r.PrettyCurrentGuesses}. You can use `/lottery change` to change an existing guess.",
 			SuccessGuessResponse r =>
-				$"Your guess for {r.Number} was recorded! Current guesses: {r.PrettyCurrentGuesses}. You can use `/lottery change` to change an existing guess. {(await GetRemainingGuesses(Context.GuildUser())).Output}",
+				$"Your guess for {r.Number} was recorded! Current guesses: {r.PrettyCurrentGuesses}. You can use `/lottery change` to change an existing guess. {(await GetRemainingGuesses(Context.GuildUser())).Output}", //Todo: add information if someone else already guessed that number and maybe who it is
 			_ => throw new NotImplementedException()
 		}, ephemeral: true);
 	}
@@ -216,7 +216,7 @@ public class LotteryInteraction : InteractionModuleBase<SocketInteractionContext
 	}
 
 
-	[SlashCommand("luckydip", "Spin the wheel and maybe you'll win!")]
+	[SlashCommand("luckydip", "Spin the wheel and maybe you'll win!")] //Todo: Idea: Repeat until the user has no guesses left
 	public async Task RandomGuess([Summary("number-pool", "Determines whether to use a random number from 1-99, unguessed or guessed numbers (default: ungessed numbers)")] RandomGuessType numberPool = RandomGuessType.UnusedOnly)
 	{
 		var cts = new CancellationTokenSource();
@@ -241,7 +241,7 @@ public class LotteryInteraction : InteractionModuleBase<SocketInteractionContext
 				NoMoreGuessesGuessResponse r =>
 					$"You don't have any guesses left! Current guesses: {r.PrettyCurrentGuesses}. You can use `/lottery change` to change an existing guess. {(await GetRemainingGuesses(Context.GuildUser())).Output}",
 				SuccessGuessResponse r =>
-					$"Your guess for {r.Number} was recorded! Current guesses: {r.PrettyCurrentGuesses}. You can use `/lottery change` to change an existing guess.",
+					$"Your guess for {r.Number} was recorded! Current guesses: {r.PrettyCurrentGuesses}. You can use `/lottery change` to change an existing guess.", //Todo: add information if someone else already guessed that number and maybe who it is
 				OutOfRangeGuessResponse => "This number pool has no valid numbers to use, try another number pool.",
 				_ => "Something went wrong, try again later. If this keeps happening, let Zahrymm know."
 			}, ephemeral: true);
@@ -324,7 +324,7 @@ public class LotteryInteraction : InteractionModuleBase<SocketInteractionContext
 			NotCurrentGuessedNumberGuessResponse _ =>
 				$"You have not guessed {old}. You need to use a number you have already guessed in order to change it.",
 			SuccessGuessResponse r =>
-				$"Your guess for {old} was changed to {@new}! Current guesses: {r.PrettyCurrentGuesses}. You can use `/lottery change` to change an existing guess.",
+				$"Your guess for {old} was changed to {@new}! Current guesses: {r.PrettyCurrentGuesses}. You can use `/lottery change` to change an existing guess.", //Todo: add information if someone else already guessed that number and maybe who it is
 			_ => throw new NotImplementedException()
 		}, ephemeral: true);
 	}

--- a/Modules/Lottery/LotteryInteraction.cs
+++ b/Modules/Lottery/LotteryInteraction.cs
@@ -186,23 +186,23 @@ public class LotteryInteraction : InteractionModuleBase<SocketInteractionContext
 	[SlashCommand("unusednumbers", "Check what numbers have not yet been used.")]
 	public async Task UnusedNumbers()
 	{
-        // var numbers = (await GetNotGuessedNumbers()).Select(num => num.ToString()).ToList().PrettyJoin();
-        var GuessedNumbers = (await GetGuessedNumbers());
+		// var numbers = (await GetNotGuessedNumbers()).Select(num => num.ToString()).ToList().PrettyJoin();
+		var GuessedNumbers = (await GetGuessedNumbers());
 
 		var lotteryRange = Enumerable.Range(1,99).ToList(); // maybe make range a config parameter
 		var formattedNumbers = lotteryRange.Select(num => GuessedNumbers.Contains(num) ? "__" : num.ToString("D2")).ToList();
 
-        //insert placeholder for the missing 0 in the first line
-        formattedNumbers.Insert(0, "xx");
+		//insert placeholder for the missing 0 in the first line
+		formattedNumbers.Insert(0, "xx");
 
-       //split into rows of 10
-        var rows = new List<string>();
-        for (int i = 0; i < formattedNumbers.Count; i+=10)
-        {
-            rows.Add(string.Join(", ", formattedNumbers.Skip(i).Take(10)));
-        }
+		//split into rows of 10
+		var rows = new List<string>();
+		for (int i = 0; i < formattedNumbers.Count; i+=10)
+		{
+			rows.Add(string.Join(", ", formattedNumbers.Skip(i).Take(10)));
+		}
 		string numbers = string.Join("\n", rows);
-        await RespondAsync($"Currently unused: {numbers}", ephemeral: true);
+		await RespondAsync($"Currently unused: {numbers}", ephemeral: true);
 	}
 
 

--- a/Modules/Lottery/LotteryInteraction.cs
+++ b/Modules/Lottery/LotteryInteraction.cs
@@ -51,9 +51,6 @@ public class LotteryInteraction : InteractionModuleBase<SocketInteractionContext
 		if (!CanParticipate(Context.GuildUser()))
 			return new NotFcMemberGuessResponse();
 
-		if (number is <= 0 or >= 100)
-			return new OutOfRangeGuessResponse();
-
 		var currentGuesses = await _lotteryGuesses
 			.Where(guess => guess.DiscordId == Context.GuildUser().Id)
 			.ToListAsync();
@@ -86,9 +83,6 @@ public class LotteryInteraction : InteractionModuleBase<SocketInteractionContext
 	{
 		if (!CanParticipate(Context.GuildUser()))
 			return new NotFcMemberGuessResponse();
-
-		if (newNumber is <= 0 or >= 100)
-			return new OutOfRangeGuessResponse();
 
 		var currentGuesses = await _lotteryGuesses
 			.Where(guess => guess.DiscordId == Context.GuildUser().Id)
@@ -159,7 +153,7 @@ public class LotteryInteraction : InteractionModuleBase<SocketInteractionContext
 	}
 
 	[SlashCommand("guess", "Pick a number and have a chance to win!")]
-	public async Task Guess(int number)
+	public async Task Guess([MinValue(1), MaxValue(99)] int number)
 	{
 		var result = await TryGuess(number);
 
@@ -173,7 +167,6 @@ public class LotteryInteraction : InteractionModuleBase<SocketInteractionContext
 		await RespondAsync(result switch
 		{
 			NotFcMemberGuessResponse _ => "Only FC members can participate in the lottery.",
-			OutOfRangeGuessResponse _ => "You can only pick a number between 1 and 99.",
 			AlreadyGuessedNumberGuessResponse _ => $"You have already guessed {number}!",
 			NoMoreGuessesGuessResponse r =>
 				$"You don't have any guesses left! Current guesses: {r.PrettyCurrentGuesses}. You can use `/lottery change` to change an existing guess.",
@@ -360,7 +353,7 @@ public class LotteryInteraction : InteractionModuleBase<SocketInteractionContext
 	}
 
 	[SlashCommand("change", "Change one of your current guesses")]
-	public async Task Change(int old, int @new)
+	public async Task Change([MinValue(1), MaxValue(99)] int old,[MinValue(1), MaxValue(99)] int @new)
 	{
 		var result = await TryChangeGuess(Context.GuildUser(), old, @new);
 
@@ -374,7 +367,6 @@ public class LotteryInteraction : InteractionModuleBase<SocketInteractionContext
 		await RespondAsync(result switch
 		{
 			NotFcMemberGuessResponse _ => "Only FC members can participate in the lottery.",
-			OutOfRangeGuessResponse _ => "You can only pick a number between 1 and 99.",
 			AlreadyGuessedNumberGuessResponse _ => $"You have already guessed {@new}.",
 			NotCurrentGuessedNumberGuessResponse _ =>
 				$"You have not guessed {old}. You need to use a number you have already guessed in order to change it.",
@@ -385,7 +377,7 @@ public class LotteryInteraction : InteractionModuleBase<SocketInteractionContext
 	}
 
 	[SlashCommand("whoguessed", "Check who has guessed a certain number.")]
-	public async Task WhoGuessed(int number)
+	public async Task WhoGuessed([MinValue(1), MaxValue(99)] int number)
 	{
 		var currentGuesses = await _lotteryGuesses
 			.Where(guess => guess.Number == number)

--- a/Modules/Lottery/LotteryInteraction.cs
+++ b/Modules/Lottery/LotteryInteraction.cs
@@ -183,26 +183,13 @@ public class LotteryInteraction : InteractionModuleBase<SocketInteractionContext
 		}, ephemeral: true);
 	}
 
-	[SlashCommand("unusednumbers", "Check what numbers have not yet been used.")]
+	[SlashCommand("unused", "Check what numbers have not yet been used.")]
 	public async Task UnusedNumbers()
 	{
-		// var numbers = (await GetNotGuessedNumbers()).Select(num => num.ToString()).ToList().PrettyJoin();
-		var GuessedNumbers = (await GetGuessedNumbers());
-
-		var lotteryRange = Enumerable.Range(1,99).ToList(); // maybe make range a config parameter
-		var formattedNumbers = lotteryRange.Select(num => GuessedNumbers.Contains(num) ? "__" : num.ToString("D2")).ToList();
-
-		//insert placeholder for the missing 0 in the first line
-		formattedNumbers.Insert(0, "xx");
-
-		//split into rows of 10
-		var rows = new List<string>();
-		for (int i = 0; i < formattedNumbers.Count; i+=10)
-		{
-			rows.Add(string.Join(", ", formattedNumbers.Skip(i).Take(10)));
-		}
-		string numbers = string.Join("\n", rows);
-		await RespondAsync($"Currently unused: \n{numbers}", ephemeral: true);
+		var guessedNumbers = (await GetGuessedNumbers());
+		var formattedNumbers = (List<string>)["  ", .. Enumerable.Range(1, 99).Select(num => guessedNumbers.Contains(num) ? "__" : num.ToString("D2"))];
+		var output = string.Join('\n', formattedNumbers.Chunk(10).Select(subList => string.Join(' ', subList)));
+		await RespondAsync($"```{output}```", ephemeral: true);
 	}
 
 

--- a/Modules/Lottery/LotteryInteraction.cs
+++ b/Modules/Lottery/LotteryInteraction.cs
@@ -302,8 +302,12 @@ public class LotteryInteraction : InteractionModuleBase<SocketInteractionContext
                 break; // Exit loop early to not retry - Optionaly could not break here to retry for every following guess.
             }
         }
-
-        await FollowupAsync(string.Join("\n", messages), ephemeral: true);
+		//Only send followup if it filled
+		if (message.Count > 0)
+		{
+			await FollowupAsync(string.Join("\n", messages), ephemeral: true);
+		}
+        
     }
 
 	private async Task<(List<LotteryGuess>? CurrentGuesses, string Output)> GetRemainingGuesses(SocketGuildUser user)


### PR DESCRIPTION
With this the luckydip command will by default only guess unused numbers.
It will also guess a number for each remaining guess.

Careful I was not able to test luckydip. 

Also limited the user input to the valid range between 1-99. 
Removed the manual checks and responses for this.